### PR TITLE
Updated the behavior of 'r' followed by anusvara

### DIFF
--- a/Mlym-Mozhi.tinker
+++ b/Mlym-Mozhi.tinker
@@ -147,7 +147,7 @@ p	> map 【ം മ്പ്】【ൽ ല്പ്】【ല്പ് ൽപ്പ
 
 q	> 【ക്ക്】
 
-r	> after 【〔AnyLetterExceptSA〕】 replace 【ം】 with 【മ്ര്】 
+r	> after 【〔AnyRegularLetterOrVowelSignExceptSA〕】 replace 【ം】 with 【മ്ര്】 
 	| after 【ൻ】 replace 【〔ZWNJ〕】 with 【ര്】
 	| after 【ർ】 replace 【〔ZWNJ〕】 with 【റ്】
 	| map 【ൻ ന്ര്】【ർ റ്】


### PR DESCRIPTION
using AnyRegularLetterOrVowelSignExceptSA is probably a better way than the previous proposal.
